### PR TITLE
These changes should fix the issue regarding duplicate headings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var parse = function (mdContent) {
         if (item.type == 'heading') {
             if (!currentHeading || item.depth == 1) {
                 headings = [];
-                result[item.text] = {};
+                result[item.text] = result[item.text] || {};
                 currentHeading = result[item.text];
                 headings.push(item.text);
             } else {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var parse = function (mdContent) {
                 var parentHeading = getParentHeading(headings, item, result);
                 headings = parentHeading.headings;
                 currentHeading = parentHeading.parent;
-                currentHeading[item.text] = {};
+                currentHeading[item.text] = currentHeading[item.text] || {};
                 currentHeading = currentHeading[item.text];
             }
         }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "ajithr",
   "license": "MIT",
   "dependencies": {
-    "marked": "^2.0.3",
+    "marked": "^5.0.0",
     "traverse": "^0.6.6"
   },
   "repository": {

--- a/spec/md-2-json-spec.js
+++ b/spec/md-2-json-spec.js
@@ -17,6 +17,10 @@ const NESTED_AND_DUPLICATE_HEADERS = `# Heading1
 Testing Duplicate 1
 ## Duplicate Heading
 Testing Duplicate 2`;
+const DUPLICATE_ROOT_HEADERS = `# ROOTHEADER
+this should not be erased.
+# ROOTHEADER
+this will not over write previous body of ROOTHEADER.`;
 
 describe("md-2-json unit testing", () => {
     it("simple content", () => {
@@ -50,5 +54,13 @@ describe("md-2-json unit testing", () => {
         };
         expect(result).toEqual(expected);
     });
-    
+    it("duplicate root headers", () => {
+        var result = PARSE(DUPLICATE_ROOT_HEADERS);
+        var expected = { 
+            "ROOTHEADER": { 
+                raw: "this should not be erased.\nthis will not over write previous body of ROOTHEADER."
+            }
+        };
+        expect(result).toEqual(expected);
+    });
 });

--- a/spec/md-2-json-spec.js
+++ b/spec/md-2-json-spec.js
@@ -39,7 +39,7 @@ describe("md-2-json unit testing", () => {
         };
         expect(result).toEqual(expected);
     });
-    it("multiple headers", () => {
+    it("duplicate headers", () => {
         var result = PARSE(NESTED_AND_DUPLICATE_HEADERS);
         var expected = { 
             "Heading1": { 

--- a/spec/md-2-json-spec.js
+++ b/spec/md-2-json-spec.js
@@ -12,6 +12,11 @@ Testing2
 
 ### Heading3
 Testing3`;
+const NESTED_AND_DUPLICATE_HEADERS = `# Heading1
+## Duplicate Heading 
+Testing Duplicate 1
+## Duplicate Heading
+Testing Duplicate 2`;
 
 describe("md-2-json unit testing", () => {
     it("simple content", () => {
@@ -34,4 +39,16 @@ describe("md-2-json unit testing", () => {
         };
         expect(result).toEqual(expected);
     });
+    it("multiple headers", () => {
+        var result = PARSE(NESTED_AND_DUPLICATE_HEADERS);
+        var expected = { 
+            "Heading1": { 
+                "Duplicate Heading":{
+                    raw: "Testing Duplicate 1\nTesting Duplicate 2",
+                },
+            }
+        };
+        expect(result).toEqual(expected);
+    });
+    
 });


### PR DESCRIPTION
Content of duplicate headings was previously overwritten by the content of the last occurrence of the heading. The content of matching headings within the same object will now be merged merged together.